### PR TITLE
Fix parseJWT when decodeJWT is not global

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@
   exports.parseJWT = function (token) {
     // TODO: Handle when decodeJWT fails.
     // TODO: Handle when JSON.parse fails.
-    return JSON.parse(decodeJWT(token));
+    return JSON.parse(exports.decodeJWT(token));
   };
 
 }());


### PR DESCRIPTION
e.g. when using browserify
